### PR TITLE
feat: Add weekly and daily task plates to HomePage

### DIFF
--- a/lib/pages/home_page/daily_task_plate.dart
+++ b/lib/pages/home_page/daily_task_plate.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DailyTaskPlate extends HookConsumerWidget {
+  const DailyTaskPlate({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = [
+      "ログインする",
+      "日記を書く",
+      "今日の歩数を記録する",
+    ];
+
+    // Placeholder for checkbox states
+    final checkboxStates = useState(List.generate(tasks.length, (_) => false));
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "デイリータスク",
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          ListView.builder(
+            shrinkWrap: true, // Important to prevent unbounded height
+            physics: const NeverScrollableScrollPhysics(), // Disable scrolling for the ListView
+            itemCount: tasks.length,
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: Text(tasks[index]),
+                trailing: Checkbox(
+                  value: checkboxStates.value[index],
+                  onChanged: (bool? newValue) {
+                    // This will be implemented in a later step
+                    // For now, we just update the local state
+                    final newStates = List<bool>.from(checkboxStates.value);
+                    newStates[index] = newValue ?? false;
+                    checkboxStates.value = newStates;
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/home_page/home_page.dart
+++ b/lib/pages/home_page/home_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sweep/pages/home_page/continuous_login_plate.dart';
+import 'package:sweep/pages/home_page/daily_task_plate.dart';
 import 'package:sweep/pages/home_page/diary_plate.dart';
 import 'package:sweep/pages/home_page/history_plate.dart';
 import 'package:sweep/pages/home_page/name_plate.dart';
 import 'package:sweep/pages/home_page/point_plate.dart';
+import 'package:sweep/pages/home_page/weekly_task_plate.dart';
 import 'package:wave/config.dart';
 import 'package:wave/wave.dart';
 
@@ -27,19 +29,10 @@ class HomePage extends HookConsumerWidget {
                   SizedBox(height: 16),
                   ContinuousLoginPlate(),
                   SizedBox(height: 16),
-                  SizedBox(
-                    height: 800,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(16),
-                        color:
-                            Theme.of(context).colorScheme.surfaceContainerLow,
-                      ),
-                      child: Center(
-                        child: Text("まだないよ"),
-                      ),
-                    ),
-                  ),
+                  WeeklyTaskPlate(),
+                  SizedBox(height: 16),
+                  DailyTaskPlate(),
+                  SizedBox(height: 16),
                 ],
               ),
             ),

--- a/lib/pages/home_page/weekly_task_plate.dart
+++ b/lib/pages/home_page/weekly_task_plate.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class WeeklyTaskPlate extends HookConsumerWidget {
+  const WeeklyTaskPlate({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = [
+      "ゴミを拾う",
+      "新しい場所を開拓する",
+      "フレンドに挨拶する",
+    ];
+
+    // Placeholder for checkbox states
+    final checkboxStates = useState(List.generate(tasks.length, (_) => false));
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "ウィークリータスク",
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          ListView.builder(
+            shrinkWrap: true, // Important to prevent unbounded height
+            physics: const NeverScrollableScrollPhysics(), // Disable scrolling for the ListView
+            itemCount: tasks.length,
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: Text(tasks[index]),
+                trailing: Checkbox(
+                  value: checkboxStates.value[index],
+                  onChanged: (bool? newValue) {
+                    // This will be implemented in a later step
+                    // For now, we just update the local state
+                    final newStates = List<bool>.from(checkboxStates.value);
+                    newStates[index] = newValue ?? false;
+                    checkboxStates.value = newStates;
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/home_page/daily_task_plate_test.dart
+++ b/test/home_page/daily_task_plate_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sweep/pages/home_page/daily_task_plate.dart';
+
+void main() {
+  testWidgets('DailyTaskPlate renders title', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DailyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('デイリータスク'), findsOneWidget);
+  });
+
+  testWidgets('DailyTaskPlate renders all example tasks', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DailyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('ログインする'), findsOneWidget);
+    expect(find.text('日記を書く'), findsOneWidget);
+    expect(find.text('今日の歩数を記録する'), findsOneWidget);
+  });
+
+  testWidgets('DailyTaskPlate checkbox toggles state', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DailyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    // Find the first checkbox
+    final checkboxFinder = find.byType(Checkbox).first;
+    
+    // Verify initial state is false
+    Checkbox checkbox = tester.widget<Checkbox>(checkboxFinder);
+    expect(checkbox.value, isFalse);
+
+    // Tap the checkbox
+    await tester.tap(checkboxFinder);
+    await tester.pump(); // Rebuild the widget with the new state
+
+    // Verify state is true after tap
+    checkbox = tester.widget<Checkbox>(checkboxFinder);
+    expect(checkbox.value, isTrue);
+  });
+}

--- a/test/home_page/weekly_task_plate_test.dart
+++ b/test/home_page/weekly_task_plate_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sweep/pages/home_page/weekly_task_plate.dart';
+
+void main() {
+  testWidgets('WeeklyTaskPlate renders title', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: WeeklyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('ウィークリータスク'), findsOneWidget);
+  });
+
+  testWidgets('WeeklyTaskPlate renders all example tasks', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: WeeklyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('ゴミを拾う'), findsOneWidget);
+    expect(find.text('新しい場所を開拓する'), findsOneWidget);
+    expect(find.text('フレンドに挨拶する'), findsOneWidget);
+  });
+
+  testWidgets('WeeklyTaskPlate checkbox toggles state', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: WeeklyTaskPlate(),
+          ),
+        ),
+      ),
+    );
+
+    // Find the first checkbox
+    final checkboxFinder = find.byType(Checkbox).first;
+    
+    // Verify initial state is false
+    Checkbox checkbox = tester.widget<Checkbox>(checkboxFinder);
+    expect(checkbox.value, isFalse);
+
+    // Tap the checkbox
+    await tester.tap(checkboxFinder);
+    await tester.pump(); // Rebuild the widget with the new state
+
+    // Verify state is true after tap
+    checkbox = tester.widget<Checkbox>(checkboxFinder);
+    expect(checkbox.value, isTrue);
+  });
+}


### PR DESCRIPTION
Adds new `WeeklyTaskPlate` and `DailyTaskPlate` widgets to the HomePage. These plates display lists of predefined weekly and daily tasks respectively, each with a checkbox to mark completion.

Key changes:
- Created `lib/pages/home_page/weekly_task_plate.dart` for the weekly task UI.
- Created `lib/pages/home_page/daily_task_plate.dart` for the daily task UI.
- Integrated these two new widgets into `lib/pages/home_page/home_page.dart`, replacing a placeholder container.
- Implemented basic state management for task completion using `useState` within each plate.
- Added widget tests in `test/home_page/weekly_task_plate_test.dart` and `test/home_page/daily_task_plate_test.dart` to verify rendering and functionality of the new task plates.