### PR TITLE
feat: Add trash achievement UI

### DIFF
--- a/lib/classes/achievement.dart
+++ b/lib/classes/achievement.dart
@@ -1,0 +1,95 @@
+// lib/classes/achievement.dart
+import 'package:meta/meta.dart';
+
+class Achievement {
+  final String id;
+  final String name;
+  final String description;
+  final String iconUrl;
+  final int criteria;
+  final bool isUnlocked;
+  final int? currentProgress; // Added field
+
+  Achievement({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.iconUrl,
+    required this.criteria,
+    this.isUnlocked = false,
+    this.currentProgress, // Added to constructor
+  });
+
+  factory Achievement.fromJson(Map<String, dynamic> json) {
+    return Achievement(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String,
+      iconUrl: json['iconUrl'] as String,
+      criteria: json['criteria'] as int,
+      isUnlocked: json['isUnlocked'] as bool? ?? false,
+      currentProgress: json['currentProgress'] as int?, // Added
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'iconUrl': iconUrl,
+      'criteria': criteria,
+      'isUnlocked': isUnlocked,
+      'currentProgress': currentProgress, // Added
+    };
+  }
+
+  Achievement copyWith({
+    String? id,
+    String? name,
+    String? description,
+    String? iconUrl,
+    int? criteria,
+    bool? isUnlocked,
+    int? currentProgress, // Added
+    bool setToNullCurrentProgress = false, // Helper to explicitly set currentProgress to null
+  }) {
+    return Achievement(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      iconUrl: iconUrl ?? this.iconUrl,
+      criteria: criteria ?? this.criteria,
+      isUnlocked: isUnlocked ?? this.isUnlocked,
+      currentProgress: setToNullCurrentProgress ? null : currentProgress ?? this.currentProgress, // Added
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Achievement &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          description == other.description &&
+          iconUrl == other.iconUrl &&
+          criteria == other.criteria &&
+          isUnlocked == other.isUnlocked &&
+          currentProgress == other.currentProgress; // Added
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      name.hashCode ^
+      description.hashCode ^
+      iconUrl.hashCode ^
+      criteria.hashCode ^
+      isUnlocked.hashCode ^
+      currentProgress.hashCode; // Added
+
+  @override
+  String toString() {
+    return 'Achievement{id: $id, name: $name, description: $description, iconUrl: $iconUrl, criteria: $criteria, isUnlocked: $isUnlocked, currentProgress: $currentProgress}'; // Added
+  }
+}

--- a/lib/data/achievements_data.dart
+++ b/lib/data/achievements_data.dart
@@ -1,0 +1,50 @@
+// lib/data/achievements_data.dart
+import 'package:sweep/classes/achievement.dart';
+
+final List<Achievement> allAchievements = [
+  Achievement(
+    id: 'trash_collector_beginner',
+    name: '見習い清掃員',
+    description: 'ゴミを5個収集する',
+    iconUrl: 'assets/images/achievements/trash_beginner.png',
+    criteria: 5,
+    isUnlocked: true, // Example: This one is unlocked
+    currentProgress: 5,
+  ),
+  Achievement(
+    id: 'trash_collector_intermediate',
+    name: '一人前の清掃員',
+    description: 'ゴミを20個収集する',
+    iconUrl: 'assets/images/achievements/trash_intermediate.png',
+    criteria: 20,
+    isUnlocked: false,
+    currentProgress: 15, // Example: Progress towards next achievement
+  ),
+  Achievement(
+    id: 'trash_collector_master',
+    name: '清掃マスター',
+    description: 'ゴミを100個収集する',
+    iconUrl: 'assets/images/achievements/trash_master.png',
+    criteria: 100,
+    isUnlocked: false,
+    currentProgress: 15, // Same progress as above, just an example
+  ),
+  Achievement(
+    id: 'area_cleaner_park',
+    name: '公園の守り手',
+    description: '公園エリアでゴミを10個収集する',
+    iconUrl: 'assets/images/achievements/park_cleaner.png',
+    criteria: 10,
+    isUnlocked: true, // Example: This one is also unlocked
+    currentProgress: 10,
+  ),
+  Achievement(
+    id: 'recycler_novice',
+    name: 'リサイクルの新人',
+    description: 'リサイクルゴミを3種類見つける',
+    iconUrl: 'assets/images/achievements/recycler_novice.png',
+    criteria: 3, // Criteria here might mean 'types of items'
+    isUnlocked: false,
+    currentProgress: 1,
+  ),
+];

--- a/lib/pages/profile_page/profile_page.dart
+++ b/lib/pages/profile_page/profile_page.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sweep/classes/profile.dart';
 import 'package:sweep/pages/home_page/plate_magin.dart';
 import 'package:sweep/states/profile_provider.dart';
+import 'package:sweep/widgets/achievements_list.dart'; // Added import
 
 class ProfilePage extends HookConsumerWidget {
   const ProfilePage({super.key});
@@ -64,6 +65,16 @@ class ProfilePage extends HookConsumerWidget {
                       title: const Text('連続ログイン日数'),
                       subtitle: Text('${profile.continuousCount} 日'),
                     ),
+                  ),
+                  const SizedBox(height: 20), // Added space before achievements section
+                  // Achievements Section
+                  Text(
+                    'アチーブメント', // Achievements Title
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  const Expanded( // Added Expanded to allow ListView to scroll
+                    child: AchievementsList(),
                   ),
                 ],
               ),

--- a/lib/states/achievements_provider.dart
+++ b/lib/states/achievements_provider.dart
@@ -1,0 +1,31 @@
+// lib/states/achievements_provider.dart
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sweep/classes/achievement.dart'; // Adjust import path
+import 'package:sweep/data/achievements_data.dart'; // Adjust import path
+
+// A simple provider that exposes the static list of all achievements.
+final achievementsDataProvider = Provider<List<Achievement>>((ref) {
+  // The UI will be responsible for interpreting 'isUnlocked' or checking criteria.
+  // For now, it returns the raw list from achievements_data.dart.
+  // If we had a simple way to get total trash count from an *existing* provider,
+  // we could update `isUnlocked` here. For example:
+  //
+  // try {
+  //   final totalTrashCollected = ref.watch(profileProvider)?.trashCount ?? 0; // Assuming 'trashCount' exists on Profile
+  //   return allAchievements.map((ach) {
+  //     bool unlocked = totalTrashCollected >= ach.criteria;
+  //     // This is a simple check. Some achievements might have different types of criteria.
+  //     // For 'area_cleaner_park', this logic is insufficient.
+  //     if (ach.id.startsWith('trash_collector')) {
+  //        return ach.copyWith(isUnlocked: unlocked);
+  //     }
+  //     return ach; // Return as is if logic is complex or data not available
+  //   }).toList();
+  // } catch (e) {
+  //   // If profileProvider is null or trashCount doesn't exist, return default list
+  //   return allAchievements;
+  // }
+  //
+  // For now, per user feedback to keep it simple and UI-focused:
+  return allAchievements;
+});

--- a/lib/widgets/achievement_item.dart
+++ b/lib/widgets/achievement_item.dart
@@ -1,0 +1,99 @@
+// lib/widgets/achievement_item.dart
+import 'package:flutter/material.dart';
+import 'package:sweep/classes/achievement.dart';
+
+class AchievementItem extends StatelessWidget {
+  final Achievement achievement;
+
+  const AchievementItem({
+    Key? key,
+    required this.achievement,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isUnlocked = achievement.isUnlocked;
+    final int progress = achievement.currentProgress ?? 0;
+    final double progressValue = achievement.criteria > 0
+                                  ? (progress / achievement.criteria).clamp(0.0, 1.0)
+                                  : 0.0;
+
+    return Card(
+      elevation: isUnlocked ? 4.0 : 1.0,
+      color: isUnlocked ? Colors.amber.shade100 : Colors.grey.shade300,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Row(
+          children: [
+            Container(
+              width: 60,
+              height: 60,
+              decoration: BoxDecoration(
+                color: isUnlocked ? Colors.amber.shade400 : Colors.grey.shade400,
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+              child: Icon(
+                isUnlocked ? Icons.emoji_events : Icons.lock_outline,
+                color: Colors.white,
+                size: 30,
+              ),
+            ),
+            const SizedBox(width: 16.0),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    achievement.name,
+                    style: TextStyle(
+                      fontSize: 18.0,
+                      fontWeight: FontWeight.bold,
+                      color: isUnlocked ? Colors.grey.shade800 : Colors.grey.shade600,
+                    ),
+                  ),
+                  const SizedBox(height: 4.0),
+                  Text(
+                    achievement.description,
+                    style: TextStyle(
+                      fontSize: 14.0,
+                      color: isUnlocked ? Colors.grey.shade700 : Colors.grey.shade500,
+                    ),
+                  ),
+                  const SizedBox(height: 8.0),
+                  if (!isUnlocked)
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '進捗: $progress / ${achievement.criteria}', // Use currentProgress
+                          style: TextStyle(
+                            fontSize: 12.0,
+                            color: Colors.grey.shade600,
+                          ),
+                        ),
+                        const SizedBox(height: 4.0),
+                        LinearProgressIndicator(
+                          value: progressValue, // Use calculated progressValue
+                          backgroundColor: Colors.grey.shade400,
+                          valueColor: AlwaysStoppedAnimation<Color>(Colors.amber.shade600),
+                        ),
+                      ],
+                    ),
+                  if (isUnlocked)
+                    Text(
+                      '達成済み!',
+                      style: TextStyle(
+                        fontSize: 14.0,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.green.shade700,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/achievements_list.dart
+++ b/lib/widgets/achievements_list.dart
@@ -1,0 +1,54 @@
+// lib/widgets/achievements_list.dart
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sweep/classes/achievement.dart';        // Adjust import path
+import 'package:sweep/states/achievements_provider.dart'; // Adjust import path
+import 'package:sweep/widgets/achievement_item.dart';   // Adjust import path
+
+class AchievementsList extends ConsumerWidget {
+  const AchievementsList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final achievementsData = ref.watch(achievementsDataProvider);
+
+    if (achievementsData.isEmpty) {
+      return const Center(
+        child: Text('アチーブメントはありません。'),
+      );
+    }
+
+    // Example: Get actual user trash count if available from an existing provider
+    // For now, this is not implemented as per user feedback to keep it UI focused.
+    // final userTrashCount = ref.watch(profileProvider)?.trashCount ?? 0; // Fictional example
+
+    return ListView.separated(
+      itemCount: achievementsData.length,
+      itemBuilder: (context, index) {
+        final achievement = achievementsData[index];
+
+        // Determine if unlocked based on some logic.
+        // For now, we'll use the 'isUnlocked' field in the mock data,
+        // or a simple check against criteria if we had a 'userTrashCount'.
+        // Since we want to keep it UI-focused and not introduce new logic in providers,
+        // we can either rely on pre-set `isUnlocked` in `achievements_data.dart`
+        // or, if we had an *existing* provider for user stats, use it here.
+        // Let's assume for now `achievement.isUnlocked` from data is the source of truth for display.
+        // If `profileProvider` (or another existing provider) had `totalTrashCollected`, we could do:
+        // final bool isActuallyUnlocked = (userTrashCount >= achievement.criteria) && achievement.id.startsWith('trash_collector');
+        // For now, we pass the achievement as is, and AchievementItem uses its isUnlocked field.
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+          child: AchievementItem(
+            achievement: achievement,
+            // We could potentially pass user progress here if it was easily available
+            // from an existing provider and AchievementItem was set up to use it.
+            // currentUserProgress: userTrashCount,
+          ),
+        );
+      },
+      separatorBuilder: (context, index) => const SizedBox(height: 8),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 // Project imports:
 import 'package:sweep/main.dart';
+import 'package:sweep/classes/achievement.dart';
+import 'package:sweep/widgets/achievement_item.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
@@ -30,5 +32,65 @@ void main() {
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
+  });
+
+  group('AchievementItem Widget Tests', () {
+    final lockedAchievement = Achievement(
+      id: 'test_locked',
+      name: 'Locked Ach',
+      description: 'This is a locked achievement.',
+      iconUrl: 'assets/icons/locked.png',
+      criteria: 10,
+      isUnlocked: false,
+      currentProgress: 5,
+    );
+
+    final unlockedAchievement = Achievement(
+      id: 'test_unlocked',
+      name: 'Unlocked Ach',
+      description: 'This is an unlocked achievement.',
+      iconUrl: 'assets/icons/unlocked.png',
+      criteria: 10,
+      isUnlocked: true,
+      currentProgress: 10,
+    );
+
+    testWidgets('renders correctly for a locked achievement', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: AchievementItem(achievement: lockedAchievement))));
+
+      // Verify name and description
+      expect(find.text('Locked Ach'), findsOneWidget);
+      expect(find.text('This is a locked achievement.'), findsOneWidget);
+
+      // Verify lock icon (specifics depend on implementation, checking for IconData here)
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+      expect(find.byIcon(Icons.emoji_events), findsNothing);
+
+      // Verify progress text and indicator
+      expect(find.text('進捗: 5 / 10'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+      // Verify "達成済み!" text is not present
+      expect(find.text('達成済み!'), findsNothing);
+    });
+
+    testWidgets('renders correctly for an unlocked achievement', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: AchievementItem(achievement: unlockedAchievement))));
+
+      // Verify name and description
+      expect(find.text('Unlocked Ach'), findsOneWidget);
+      expect(find.text('This is an unlocked achievement.'), findsOneWidget);
+
+      // Verify achievement icon
+      expect(find.byIcon(Icons.emoji_events), findsOneWidget);
+      expect(find.byIcon(Icons.lock_outline), findsNothing);
+
+      // Verify "達成済み!" text is present
+      expect(find.text('達成済み!'), findsOneWidget);
+
+      // Verify progress text and indicator are not present
+      expect(find.textContaining('進捗:'), findsNothing);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
    Implements a new UI for displaying your achievements related to trash collection.

    Key changes:
    - Defined an `Achievement` class to hold achievement data (name, description, criteria, progress, unlocked status).
    - Added mock data for various achievements, including examples of locked, in-progress, and unlocked states.
    - Created an `achievementsDataProvider` to make this data available to the UI.
    - Developed new UI components:
        - `AchievementItem`: Displays individual achievement details, including icon, name, description, progress bar (for locked items), and visual distinction for unlocked items.
        - `AchievementsList`: Displays a list of all achievements.
    - Integrated the `AchievementsList` into the `ProfilePage`, appearing as a new "アチーブメント" section.
    - Added basic widget tests for the `AchievementItem` to verify rendering based on achievement state.

    This feature provides the foundational UI for achievements. Further work would involve integrating with backend services to track real user progress and unlock achievements dynamically.